### PR TITLE
Fix s3_write example for new interface

### DIFF
--- a/examples/s3_write.go
+++ b/examples/s3_write.go
@@ -25,7 +25,7 @@ func s3Example() {
 	num := 100
 
 	// create new S3 file writer
-	fw, err := s3.NewS3FileWriter(ctx, bucket, key)
+	fw, err := s3.NewS3FileWriter(ctx, bucket, key, nil)
 	if err != nil {
 		log.Println("Can't open file", err)
 		return


### PR DESCRIPTION
The interface to NewS3FileWriter changed, this fixes the example.