### PR TITLE
go.mod should use correct URL of module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module parquet-go-source
+module github.com/xitongsys/parquet-go-source
 
 go 1.14
 


### PR DESCRIPTION
Otherwise, installing the module yields something along the lines of:

```
go get: github.com/xitongsys/parquet-go-source@v0.0.0-20200326031722-42b453e70c3b updating to
	github.com/xitongsys/parquet-go-source@v0.0.0-20200502003254-3a4231c65b99: parsing go.mod:
	module declares its path as: parquet-go-source
	        but was required as: github.com/xitongsys/parquet-go-source
```