### PR TITLE
Fix writer error on writing bytes array

### DIFF
--- a/examples/gcs_write.go
+++ b/examples/gcs_write.go
@@ -53,7 +53,7 @@ func main() {
 		}
 
 		data2 := []interface{}{
-			[]byte("Student Name"),
+			"Student Name",
 			int32(20 + i%5),
 			int64(i),
 			float32(50.0 + float32(i)*0.1),


### PR DESCRIPTION
Don't know if writer should be capable to handle bytes array. If it should then with should be implemented on its side rather than in the example.

https://github.com/xitongsys/parquet-go-source/issues/17