### PR TITLE
Using S3File context when interacting with S3 API

### DIFF
--- a/s3/s3.go
+++ b/s3/s3.go
@@ -182,7 +182,7 @@ func (s *S3File) Read(p []byte) (n int, err error) {
 	}
 
 	wab := aws.NewWriteAtBuffer(p)
-	bytesDownloaded, err := s.downloader.Download(wab, getObj)
+	bytesDownloaded, err := s.downloader.DownloadWithContext(s.ctx, wab, getObj)
 	if err != nil {
 		return 0, err
 	}
@@ -312,7 +312,7 @@ func (s *S3File) openWrite() {
 		defer close(done)
 
 		// upload data and signal done when complete
-		_, err := uploader.Upload(params)
+		_, err := uploader.UploadWithContext(s.ctx, params)
 		if err != nil {
 			s.lock.Lock()
 			s.err = err
@@ -335,7 +335,7 @@ func (s *S3File) openRead() error {
 		Key:    aws.String(s.Key),
 	}
 
-	hoo, err := s.client.HeadObject(hoi)
+	hoo, err := s.client.HeadObjectWithContext(s.ctx, hoi)
 	if err != nil {
 		return err
 	}

--- a/s3/s3_test.go
+++ b/s3/s3_test.go
@@ -270,11 +270,12 @@ func TestOpen(t *testing.T) {
 	key := "test/foobar.parquet"
 	fileSize := int64(123)
 
+	ctx := context.Background()
 	mockClient := mocks.NewMockS3API(ctrl)
-	mockClient.EXPECT().HeadObject(gomock.Any()).
+	mockClient.EXPECT().HeadObjectWithContext(ctx, gomock.Any()).
 		Return(&s3.HeadObjectOutput{ContentLength: aws.Int64(fileSize)}, nil)
 	s := &S3File{
-		ctx:        context.Background(),
+		ctx:        ctx,
 		BucketName: bucket,
 		client:     mockClient,
 	}
@@ -428,9 +429,10 @@ func TestOpenReadFileSizeError(t *testing.T) {
 	bucket := "test-bucket"
 	key := "test/foobar.parquet"
 
+	ctx := context.Background()
 	mockClient := mocks.NewMockS3API(ctrl)
-	mockClient.EXPECT().HeadObject(gomock.Any()).
-		DoAndReturn(func(hoi *s3.HeadObjectInput) (*s3.HeadObjectOutput, error) {
+	mockClient.EXPECT().HeadObjectWithContext(ctx, gomock.Any()).
+		DoAndReturn(func(_ context.Context, hoi *s3.HeadObjectInput) (*s3.HeadObjectOutput, error) {
 			if *hoi.Bucket != bucket {
 				t.Errorf("expected bucket %q but got %q", bucket, *hoi.Bucket)
 			}
@@ -443,6 +445,7 @@ func TestOpenReadFileSizeError(t *testing.T) {
 		})
 
 	s := &S3File{
+		ctx:        ctx,
 		BucketName: bucket,
 		Key:        key,
 		client:     mockClient,
@@ -462,9 +465,10 @@ func TestOpenRead(t *testing.T) {
 	key := "test/foobar.parquet"
 	filesize := int64(123)
 
+	ctx := context.Background()
 	mockClient := mocks.NewMockS3API(ctrl)
-	mockClient.EXPECT().HeadObject(gomock.Any()).
-		DoAndReturn(func(hoi *s3.HeadObjectInput) (*s3.HeadObjectOutput, error) {
+	mockClient.EXPECT().HeadObjectWithContext(ctx, gomock.Any()).
+		DoAndReturn(func(_ context.Context, hoi *s3.HeadObjectInput) (*s3.HeadObjectOutput, error) {
 			if *hoi.Bucket != bucket {
 				t.Errorf("expected bucket %q but got %q", bucket, *hoi.Bucket)
 			}
@@ -477,6 +481,7 @@ func TestOpenRead(t *testing.T) {
 		})
 
 	s := &S3File{
+		ctx:        ctx,
 		BucketName: bucket,
 		Key:        key,
 		client:     mockClient,


### PR DESCRIPTION
The S3File has a context setup, but it isn't used in any of the S3 API calls.  This connects those pieces.