### PR TITLE
Returning a BufferFile

### DIFF
--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -22,14 +22,14 @@ func NewBufferFile(b []byte) (BufferFile, error) {
 	}, nil
 }
 
-func (bf BufferFile) Create(name string) (BufferFile, error) {
+func (bf BufferFile) Create(name string) (source.ParquetFile, error) {
 	return BufferFile{
 		Reader: bytes.NewReader(make([]byte, 0)),
 		Writer: bytes.NewBuffer(make([]byte, 0)),
 	}, nil
 }
 
-func (bf BufferFile) Open(name string) (BufferFile, error) {
+func (bf BufferFile) Open(name string) (source.ParquetFile, error) {
 	return BufferFile{
 		Reader: bytes.NewReader(bf.buff),
 		Writer: bytes.NewBuffer(bf.buff),

--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -14,7 +14,7 @@ type BufferFile struct {
 }
 
 // NewBufferFile creates new in memory parquet buffer.
-func NewBufferFile(b []byte) (source.ParquetFile, error) {
+func NewBufferFile(b []byte) (BufferFile, error) {
 	return BufferFile{
 		Reader: bytes.NewReader(b),
 		Writer: bytes.NewBuffer(b),
@@ -22,14 +22,14 @@ func NewBufferFile(b []byte) (source.ParquetFile, error) {
 	}, nil
 }
 
-func (bf BufferFile) Create(name string) (source.ParquetFile, error) {
+func (bf BufferFile) Create(name string) (BufferFile, error) {
 	return BufferFile{
 		Reader: bytes.NewReader(make([]byte, 0)),
 		Writer: bytes.NewBuffer(make([]byte, 0)),
 	}, nil
 }
 
-func (bf BufferFile) Open(name string) (source.ParquetFile, error) {
+func (bf BufferFile) Open(name string) (BufferFile, error) {
 	return BufferFile{
 		Reader: bytes.NewReader(bf.buff),
 		Writer: bytes.NewBuffer(bf.buff),


### PR DESCRIPTION
In the buffer package a source.ParquetFile was returned, instead of a BufferFile. Since this caused the Bytes()-method to be unavailable, this didn't seem right. Changed it to a BufferFile, to be able to use the type.