### PR TITLE
Reduce the number of requests made by S3Files

### DIFF
--- a/s3/s3_test.go
+++ b/s3/s3_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/s3"
-	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	"github.com/golang/mock/gomock"
 	"github.com/xitongsys/parquet-go-source/s3/mocks"
 )
@@ -84,13 +83,11 @@ func TestReadBodyLargerThanProvidedBuffer(t *testing.T) {
 	bufReadCloser := ioutil.NopCloser(buf)
 	mockClient := mocks.NewMockS3API(ctrl)
 	mockClient.EXPECT().GetObjectWithContext(gomock.Any(), gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, input *s3.GetObjectInput, opts ...request.Option) (*s3.GetObjectOutput, error) {
-			return &s3.GetObjectOutput{Body: bufReadCloser}, nil
-		})
-	s := &S3File{
-		fileSize:   100,
-		offset:     10,
-		downloader: s3manager.NewDownloaderWithClient(mockClient),
+		Return(&s3.GetObjectOutput{Body: bufReadCloser}, nil)
+	s := S3File{
+		client:   mockClient,
+		fileSize: 100,
+		offset:   10,
 	}
 
 	b := make([]byte, 4)
@@ -113,13 +110,11 @@ func TestReadDownloadError(t *testing.T) {
 	bufReadCloser := ioutil.NopCloser(buf)
 	mockClient := mocks.NewMockS3API(ctrl)
 	mockClient.EXPECT().GetObjectWithContext(gomock.Any(), gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, input *s3.GetObjectInput, opts ...request.Option) (*s3.GetObjectOutput, error) {
-			return &s3.GetObjectOutput{Body: bufReadCloser}, errors.New(errMessage)
-		})
+		Return(&s3.GetObjectOutput{Body: bufReadCloser}, errors.New(errMessage))
 	s := &S3File{
-		fileSize:   100,
-		offset:     10,
-		downloader: s3manager.NewDownloaderWithClient(mockClient),
+		client:   mockClient,
+		fileSize: 100,
+		offset:   10,
 	}
 
 	b := make([]byte, 4)
@@ -142,13 +137,11 @@ func TestRead(t *testing.T) {
 	bufReadCloser := ioutil.NopCloser(buf)
 	mockClient := mocks.NewMockS3API(ctrl)
 	mockClient.EXPECT().GetObjectWithContext(gomock.Any(), gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, input *s3.GetObjectInput, opts ...request.Option) (*s3.GetObjectOutput, error) {
-			return &s3.GetObjectOutput{Body: bufReadCloser}, nil
-		})
+		Return(&s3.GetObjectOutput{Body: bufReadCloser}, nil)
 	s := &S3File{
-		fileSize:   100,
-		offset:     0,
-		downloader: s3manager.NewDownloaderWithClient(mockClient),
+		client:   mockClient,
+		fileSize: 100,
+		offset:   0,
 	}
 
 	b := make([]byte, 9)

--- a/s3v2/s3_test.go
+++ b/s3v2/s3_test.go
@@ -8,7 +8,6 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/golang/mock/gomock"
 	"github.com/xitongsys/parquet-go-source/s3v2/mocks"
@@ -81,13 +80,11 @@ func TestReadBodyLargerThanProvidedBuffer(t *testing.T) {
 	bufReadCloser := ioutil.NopCloser(buf)
 	mockClient := mocks.NewMockS3API(ctrl)
 	mockClient.EXPECT().GetObject(gomock.Any(), gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, input *s3.GetObjectInput, opts ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
-			return &s3.GetObjectOutput{Body: bufReadCloser}, nil
-		})
+		Return(&s3.GetObjectOutput{Body: bufReadCloser}, nil)
 	s := &S3File{
-		fileSize:   100,
-		offset:     10,
-		downloader: manager.NewDownloader(mockClient),
+		client:   mockClient,
+		fileSize: 100,
+		offset:   10,
 	}
 
 	b := make([]byte, 4)
@@ -110,13 +107,11 @@ func TestReadDownloadError(t *testing.T) {
 	bufReadCloser := ioutil.NopCloser(buf)
 	mockClient := mocks.NewMockS3API(ctrl)
 	mockClient.EXPECT().GetObject(gomock.Any(), gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, input *s3.GetObjectInput, opts ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
-			return &s3.GetObjectOutput{Body: bufReadCloser}, errors.New(errMessage)
-		})
+		Return(&s3.GetObjectOutput{Body: bufReadCloser}, errors.New(errMessage))
 	s := &S3File{
-		fileSize:   100,
-		offset:     10,
-		downloader: manager.NewDownloader(mockClient),
+		client:   mockClient,
+		fileSize: 100,
+		offset:   10,
 	}
 
 	b := make([]byte, 4)
@@ -139,13 +134,11 @@ func TestRead(t *testing.T) {
 	bufReadCloser := ioutil.NopCloser(buf)
 	mockClient := mocks.NewMockS3API(ctrl)
 	mockClient.EXPECT().GetObject(gomock.Any(), gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, input *s3.GetObjectInput, opts ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
-			return &s3.GetObjectOutput{Body: bufReadCloser}, nil
-		})
+		Return(&s3.GetObjectOutput{Body: bufReadCloser}, nil)
 	s := &S3File{
-		fileSize:   100,
-		offset:     0,
-		downloader: manager.NewDownloader(mockClient),
+		client:   mockClient,
+		fileSize: 100,
+		offset:   0,
 	}
 
 	b := make([]byte, 9)


### PR DESCRIPTION
As written, the S3File implementations issue one request to AWS per call
to Read. When the ParquetReader issues repeated small Read calls, this
results in a large number of S3 GetObject requests, which causes bad
performance and high AWS costs.

This commit reimplements the reader logic for the two versions of S3File
in the following way:

When reading, if there is no open reader into the S3 object, it issues a
GetObject request with a large range and stores the io.ReadCloser into
the body in the S3File object. This io.ReadCloser will be serve any
incoming Read calls. When the ParquetReader Seeks to a new location in
the file or an error occurs while reading the file, the io.ReadCloser is
closed and discarded, and the next call to Read will issue a new
request.

A new configuration parameter "MinRequestSize" is added to control the
amount of over-fetching. If not specified, we pick a generous default.

A new constructor NewS3FileReaderWithParams is added, which accepts a
new S3FileReaderParams that contains all the fields used to construct
an S3File for reading. This should help mitigate the problem of
proliferating constructors for different sets of configuration
parameters - the caller sets the parameters they care about and ignores
the ones they don't, and the constructor handles default behavior.

---

Comparing the s3-stream branch against the master branch (using the current latest parquet-go) shows enormous performance improvements, so much so that it's actually a bit hard to show apples-to-apples comparisons.

master: 

Elements | Time | GetObject requests
-------- | ---- | -----------------
1000 | 3.21s | 18
10000 | 16.72s | 140
100000 | 2m42.99s | 1370

This commit:

Elements | Time | GetObject requests
-------- | ---- | -----------------
1000 | 2.07s | 4
10000 | 2.31s | 4
100000 | 3.98s | 4
1000000 | 34.65s | 4
10000000 | 4m11.99s | 12



