### PR TITLE
Support s3 io.SeekEnd with 0 offset

### DIFF
--- a/s3/s3.go
+++ b/s3/s3.go
@@ -152,7 +152,9 @@ func (s *S3File) Seek(offset int64, whence int) (int64, error) {
 				return 0, errInvalidOffset
 			}
 		case io.SeekEnd:
-			if offset > -1 || -offset > s.fileSize {
+			if offset == 0 {
+				offset = s.fileSize
+			} else if offset > 0 || -offset > s.fileSize {
 				return 0, errInvalidOffset
 			}
 		}

--- a/s3/s3_test.go
+++ b/s3/s3_test.go
@@ -35,6 +35,7 @@ func TestSeek(t *testing.T) {
 		{"seek current read past end", 20, 10, 20, io.SeekCurrent, 0, errInvalidOffset},
 		{"seek end", 20, 10, -5, io.SeekEnd, -5, nil},
 		{"seek end read past beginning", 20, 0, -30, io.SeekEnd, 0, errInvalidOffset},
+		{"seek end offset 0", 20, 0, 0, io.SeekEnd, 20, nil},
 		{"invalid whence", 20, 0, 0, 6, 0, errWhence},
 	}
 

--- a/s3v2/s3.go
+++ b/s3v2/s3.go
@@ -163,7 +163,9 @@ func (s *S3File) Seek(offset int64, whence int) (int64, error) {
 				return 0, errInvalidOffset
 			}
 		case io.SeekEnd:
-			if offset > -1 || -offset > s.fileSize {
+			if offset == 0 {
+				offset = s.fileSize
+			} else if offset > 0 || -offset > s.fileSize {
 				return 0, errInvalidOffset
 			}
 		}

--- a/s3v2/s3_test.go
+++ b/s3v2/s3_test.go
@@ -33,6 +33,7 @@ func TestSeek(t *testing.T) {
 		{"seek current read past end", 20, 10, 20, io.SeekCurrent, 0, errInvalidOffset},
 		{"seek end", 20, 10, -5, io.SeekEnd, -5, nil},
 		{"seek end read past beginning", 20, 0, -30, io.SeekEnd, 0, errInvalidOffset},
+		{"seek end offset 0", 20, 0, 0, io.SeekEnd, 20, nil},
 		{"invalid whence", 20, 0, 0, 6, 0, errWhence},
 	}
 


### PR DESCRIPTION
```
f.Seek(0, io.SeekEnd)
```
Should be supported by the interface and should set the offset to the filesize, without this implementation is not usable with some libraries.

```
f, err := os.Open("/tmp/somefile")
require.NoError(t, err)
n, err := f.Seek(0, io.SeekEnd) <- n == filesize
require.NoError(t, err)
```