### PR TITLE
Support gcs io.SeekEnd with 0 offset

### DIFF
--- a/gcs/gcs.go
+++ b/gcs/gcs.go
@@ -145,7 +145,9 @@ func (self *GcsFile) Seek(offset int64, whence int) (int64, error) {
 				return 0, errInvalidOffset
 			}
 		case io.SeekEnd:
-			if offset > -1 || -offset > self.fileSize {
+			if offset == 0 {
+				offset = self.fileSize
+			} else if offset > 0 || -offset > self.fileSize {
 				return 0, errInvalidOffset
 			}
 		}


### PR DESCRIPTION
```
f.Seek(0, io.SeekEnd)
```
Should be supported by the interface and should set the offset to the filesize, without this implementation is not usable with some libraries.

```
f, err := os.Open("/tmp/somefile")
require.NoError(t, err)
n, err := f.Seek(0, io.SeekEnd) <- n == filesize
require.NoError(t, err)
```