### PR TITLE
feat: add `NewBufferFileFromBytesNoAlloc`

### DIFF
--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -22,10 +22,17 @@ func NewBufferFile() *BufferFile {
 }
 
 // NewBufferFileFromBytes creates new in memory parquet buffer from the given bytes.
+// It allocates a new slice and copy the contents of s.
 func NewBufferFileFromBytes(s []byte) *BufferFile {
 	b := make([]byte, len(s))
 	copy(b, s)
 	return &BufferFile{buff: b}
+}
+
+// NewBufferFileFromBytes creates new in memory parquet buffer from the given bytes.
+// It uses the provided slice as its buffer.
+func NewBufferFileFromBytesNoAlloc(s []byte) *BufferFile {
+	return &BufferFile{buff: s}
 }
 
 // NewBufferFileCapacity starts the returned BufferFile with the given capacity


### PR DESCRIPTION
The current implementation of `NewBufferFileFromBytes`  creates a copy of the slice provide, doubling its usage in memory, this commit provides a new function  `NewBufferFileFromBytesNoAlloc`, that will used the passed bytes slice as its buffer