### PR TITLE
fix: Speed up GCS reader

### DIFF
--- a/gcs/gcs.go
+++ b/gcs/gcs.go
@@ -2,219 +2,116 @@ package gcs
 
 import (
 	"context"
-	"errors"
-	"io"
+	"fmt"
 
 	"cloud.google.com/go/storage"
+	"github.com/bobg/gcsobj"
 	"github.com/xitongsys/parquet-go/source"
 )
 
-var (
-	errWhence        = errors.New("Seek: invalid whence")
-	errInvalidOffset = errors.New("Seek: invalid offset")
-)
+// Compile time check that *File implement the source.ParquetFile interface.
+var _ source.ParquetFile = &File{}
 
-type GcsFile struct {
-	ProjectId  string
+// File represents a File that can be read from or written to.
+type File struct {
+	ProjectID  string
 	BucketName string
-	Ctx        context.Context
+	FilePath   string
 
-	Client         *storage.Client
-	externalClient bool
-	Bucket         *storage.BucketHandle
-	FilePath       string
-	FileReader     *storage.Reader
-	FileWriter     *storage.Writer
-
-	offset   int64
-	whence   int
-	fileSize int64
+	gcsReader *gcsobj.Reader
+	gcsWriter *storage.Writer
+	object    *storage.ObjectHandle
+	ctx       context.Context //nolint:containedctx // Needed to create new readers and writers
 }
 
-func NewGcsFileWriter(ctx context.Context, projectId string, bucketName string, name string) (source.ParquetFile, error) {
-	res := &GcsFile{
-		ProjectId:  projectId,
-		BucketName: bucketName,
-		Ctx:        ctx,
-		FilePath:   name,
-	}
-	return res.Create(name)
+// NewGcsFileWriter will create a new GCS file writer.
+func NewGcsFileWriter(ctx context.Context, projectID, bucketName, name string) (*File, error) {
+	return NewGcsFileReader(ctx, projectID, bucketName, name)
 }
 
-func NewGcsFileWriterWithClient(ctx context.Context, client *storage.Client, projectId string, bucketName string, name string) (source.ParquetFile, error) {
-	res := &GcsFile{
-		ProjectId:      projectId,
-		BucketName:     bucketName,
-		Ctx:            ctx,
-		Client:         client,
-		externalClient: true,
-		FilePath:       name,
-	}
-	return res.Create(name)
+// NewGcsFileWriter will create a new GCS file writer with the passed client.
+func NewGcsFileWriterWithClient(ctx context.Context, client *storage.Client, projectID, bucketName, name string) (*File, error) {
+	return NewGcsFileReaderWithClient(ctx, client, projectID, bucketName, name)
 }
 
-func NewGcsFileReader(ctx context.Context, projectId string, bucketName string, name string) (source.ParquetFile, error) {
-	res := &GcsFile{
-		ProjectId:  projectId,
-		BucketName: bucketName,
-		Ctx:        ctx,
-		FilePath:   name,
-	}
-	return res.Open(name)
-}
-
-func NewGcsFileReaderWithClient(ctx context.Context, client *storage.Client, projectId string, bucketName string, name string) (source.ParquetFile, error) {
-	res := &GcsFile{
-		ProjectId:      projectId,
-		BucketName:     bucketName,
-		Ctx:            ctx,
-		Client:         client,
-		externalClient: true,
-		FilePath:       name,
-	}
-	return res.Open(name)
-}
-
-func (self *GcsFile) Create(name string) (source.ParquetFile, error) {
-	var err error
-	gcs := new(GcsFile)
-	if self.Client == nil {
-		gcs.Client, err = storage.NewClient(self.Ctx)
-		gcs.externalClient = false
-	} else {
-		gcs.Client = self.Client
-		gcs.externalClient = self.externalClient
-	}
-	gcs.FilePath = name
+// NewGcsFileWriter will create a new GCS file reader.
+func NewGcsFileReader(ctx context.Context, projectID, bucketName, name string) (*File, error) {
+	client, err := storage.NewClient(ctx)
 	if err != nil {
-		return gcs, err
+		return nil, fmt.Errorf("failed to create storage client: %w", err)
 	}
-	// must use existing bucket
-	gcs.Bucket = gcs.Client.Bucket(self.BucketName)
-	obj := gcs.Bucket.Object(name)
-	gcs.FileWriter = obj.NewWriter(self.Ctx)
-	return gcs, err
+
+	return NewGcsFileReaderWithClient(ctx, client, projectID, bucketName, name)
 }
 
-func (self *GcsFile) Open(name string) (source.ParquetFile, error) {
-	var err error
-	gcs := new(GcsFile)
-	if self.Client == nil {
-		gcs.Client, err = storage.NewClient(self.Ctx)
-		gcs.externalClient = false
-	} else {
-		gcs.Client = self.Client
-		gcs.externalClient = self.externalClient
-	}
+// NewGcsFileWriter will create a new GCS file reader with the passed client.
+func NewGcsFileReaderWithClient(ctx context.Context, client *storage.Client, projectID, bucketName, name string) (*File, error) {
+	bucket := client.Bucket(bucketName)
+	obj := bucket.Object(name)
+
+	reader, err := gcsobj.NewReader(ctx, obj)
 	if err != nil {
-		return gcs, err
+		return nil, fmt.Errorf("failed to create new reader: %w", err)
 	}
+
+	return &File{
+		ProjectID:  projectID,
+		BucketName: bucketName,
+		FilePath:   name,
+		gcsReader:  reader,
+		object:     obj,
+		ctx:        ctx,
+	}, nil
+}
+
+// Open will create a new GCS file reader/writer and open the object named as
+// the passed named. If name is left empty the same object as currently opened
+// will be re-opened.
+func (g *File) Open(name string) (source.ParquetFile, error) {
 	if name == "" {
-		gcs.FilePath = self.FilePath
-	} else {
-		gcs.FilePath = name
+		name = g.FilePath
 	}
-	// must use existing bucket
-	gcs.Bucket = gcs.Client.Bucket(self.BucketName)
-	obj := gcs.Bucket.Object(gcs.FilePath)
-	attrs, err := obj.Attrs(self.Ctx)
-	if err != nil {
-		return gcs, err
-	}
-	gcs.fileSize = attrs.Size
-	gcs.Ctx = self.Ctx
-	gcs.ProjectId = self.ProjectId
-	gcs.BucketName = self.BucketName
-	return gcs, err
+
+	return NewGcsFileReader(g.ctx, g.ProjectID, g.BucketName, name)
 }
 
-func (self *GcsFile) Seek(offset int64, whence int) (int64, error) {
-	if whence < io.SeekStart || whence > io.SeekEnd {
-		return 0, errWhence
+// Create will create a new GCS file reader/writer and open the object named as
+// the passed named. If name is left empty the same object as currently opened
+// will be re-opened.
+func (g *File) Create(name string) (source.ParquetFile, error) {
+	if name == "" {
+		name = g.FilePath
 	}
 
-	if self.fileSize > 0 {
-		switch whence {
-		case io.SeekStart:
-			if offset < 0 || offset > self.fileSize {
-				return 0, errInvalidOffset
-			}
-		case io.SeekCurrent:
-			offset += self.offset
-			if offset < 0 || offset > self.fileSize {
-				return 0, errInvalidOffset
-			}
-		case io.SeekEnd:
-			if offset == 0 {
-				offset = self.fileSize
-			} else if offset > 0 || -offset > self.fileSize {
-				return 0, errInvalidOffset
-			}
-		}
-	}
-
-	self.offset = offset
-	self.whence = whence
-	return self.offset, nil
+	return NewGcsFileReader(g.ctx, g.ProjectID, g.BucketName, name)
 }
 
-func (self *GcsFile) Read(b []byte) (cnt int, err error) {
-	if self.fileSize > 0 && self.offset >= self.fileSize {
-		return 0, io.EOF
-	}
-
-	ln := len(b)
-
-	obj := self.Bucket.Object(self.FilePath)
-	if self.offset == 0 {
-		self.FileReader, err = obj.NewReader(self.Ctx)
-	} else {
-		var length int64
-		if self.offset < 0 || (self.whence == io.SeekEnd && int64(ln) >= self.fileSize-self.offset) {
-			length = -1
-		} else {
-			length = int64(ln)
-		}
-		self.FileReader, err = obj.NewRangeReader(self.Ctx, self.offset, length)
-		if err != nil {
-			return
-		}
-	}
-	defer self.FileReader.Close()
-
-	var n int
-	for cnt < ln {
-		n, err = self.FileReader.Read(b[cnt:])
-		cnt += n
-		if err != nil {
-			break
-		}
-	}
-	self.offset += int64(cnt)
-	return cnt, err
+// Seek implements io.Seeker.
+func (g *File) Seek(offset int64, whence int) (int64, error) {
+	return g.gcsReader.Seek(offset, whence)
 }
 
-func (self *GcsFile) Write(b []byte) (n int, err error) {
-	return self.FileWriter.Write(b)
+// Read implements io.Reader.
+func (g *File) Read(b []byte) (cnt int, err error) {
+	return g.gcsReader.Read(b)
 }
 
-func (self *GcsFile) Close() error {
-	if self.FileReader != nil {
-		if err := self.FileReader.Close(); err != nil {
+// Write implements io.Writer.
+func (g *File) Write(b []byte) (n int, err error) {
+	if g.gcsWriter == nil {
+		g.gcsWriter = g.object.NewWriter(g.ctx)
+	}
+
+	return g.gcsWriter.Write(b)
+}
+
+// Close implements io.Closer.
+func (g *File) Close() error {
+	if g.gcsWriter != nil {
+		if err := g.gcsWriter.Close(); err != nil {
 			return err
 		}
 	}
-	if self.FileWriter != nil {
-		if err := self.FileWriter.Close(); err != nil {
-			return err
-		}
-	}
-	if self.Client != nil && !self.externalClient {
-		err := self.Client.Close()
-		self.Client = nil
-		if err != nil {
-			return err
-		}
-	}
-	return nil
+
+	return g.gcsReader.Close()
 }

--- a/gcs/gcs.go
+++ b/gcs/gcs.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Compile time check that *File implement the source.ParquetFile interface.
-var _ source.ParquetFile = &File{}
+var _ source.ParquetFile = (*File)(nil)
 
 // File represents a File that can be read from or written to.
 type File struct {

--- a/gcs/gcs.go
+++ b/gcs/gcs.go
@@ -126,7 +126,7 @@ func (g *File) Write(b []byte) (int, error) {
 
 // Close implements io.Closer.
 func (g *File) Close() error {
-	if !g.externalClient {
+	if !g.externalClient && g.gcsClient != nil {
 		if err := g.gcsClient.Close(); err != nil {
 			return err
 		}
@@ -138,6 +138,8 @@ func (g *File) Close() error {
 		if err := g.gcsWriter.Close(); err != nil {
 			return err
 		}
+
+		g.gcsWriter = nil
 	}
 
 	return g.gcsReader.Close()

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.15.3
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.11.3
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.26.3
+	github.com/bobg/gcsobj v0.1.2 // indirect
 	github.com/colinmarc/hdfs/v2 v2.1.1
 	github.com/golang/mock v1.6.0
 	github.com/minio/minio-go/v7 v7.0.34

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,7 @@ cloud.google.com/go v0.56.0/go.mod h1:jr7tqZxxKOVYizybht9+26Z/gUq7tiRzu+ACVAMbKV
 cloud.google.com/go v0.57.0/go.mod h1:oXiQ6Rzq3RAkkY7N6t3TcE6jE+CIBBbA36lwQ1JyzZs=
 cloud.google.com/go v0.62.0/go.mod h1:jmCYTdRCQuc1PHIIJ/maLInMho30T/Y0M4hTdTShOYc=
 cloud.google.com/go v0.65.0/go.mod h1:O5N8zS7uWy9vkA9vayVHs65eM1ubvY4h553ofrNHObY=
+cloud.google.com/go v0.66.0/go.mod h1:dgqGAjKCDxyhGTtC9dAREQGUJpkceNm1yt590Qno0Ko=
 cloud.google.com/go v0.72.0/go.mod h1:M+5Vjvlc2wnp6tjzE102Dw08nGShTscUx2nZMufOKPI=
 cloud.google.com/go v0.74.0/go.mod h1:VV1xSbzvo+9QJOxLDaJfTjx5e+MePCpCWwvftOeQmWk=
 cloud.google.com/go v0.78.0/go.mod h1:QjdrLG0uq+YwhjoVOLsS1t7TW8fs36kLs4XO5R5ECHg=
@@ -63,6 +64,7 @@ cloud.google.com/go/storage v1.5.0/go.mod h1:tpKbwo567HUNpVclU5sGELwQWBDZ8gh0Zeo
 cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohlUTyfDhBk=
 cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RXyy7KQOVs=
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
+cloud.google.com/go/storage v1.12.0/go.mod h1:fFLk2dp2oAhDz8QFKwqrjdJvxSp/W2g7nillojlL5Ho=
 cloud.google.com/go/storage v1.21.0 h1:HwnT2u2D309SFDHQII6m18HlrCi3jAXhUMTLOWXYH14=
 cloud.google.com/go/storage v1.21.0/go.mod h1:XmRlxkgPjlBONznT2dDUU/5XlpU2OjMnKuqnZI01LAA=
 cloud.google.com/go/trace v1.0.0/go.mod h1:4iErSByzxkyHWzzlAj63/Gmjz0NH1ASqhJguHpGcr6A=
@@ -170,6 +172,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.16.3/go.mod h1:bfBj0iVmsUyUg4weDB4Nx
 github.com/aws/smithy-go v1.11.2 h1:eG/N+CcUMAvsdffgMvjMKwfyDzIkjM6pfxMJ8Mzc6mE=
 github.com/aws/smithy-go v1.11.2/go.mod h1:3xHYmszWVx2c0kIwQeEVf9uSm4fYZt67FBJnwub1bgM=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
+github.com/bobg/gcsobj v0.1.2 h1:1xA5ybDt4HA3Z1BDTS6DdKkUUHOf0MIXT9hstZFNsD4=
+github.com/bobg/gcsobj v0.1.2/go.mod h1:vS49EQ1A1Ib8FgrL58C8xXYZyOCR2TgzAdopy6/ipa8=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/census-instrumentation/opencensus-proto v0.3.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
@@ -321,6 +325,7 @@ github.com/google/pprof v0.0.0-20200212024743-f11f1df84d12/go.mod h1:ZgVRPoUq/hf
 github.com/google/pprof v0.0.0-20200229191704-1ebb73c60ed3/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20200430221834-fc25d7d30c6d/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
+github.com/google/pprof v0.0.0-20200905233945-acf8798be1f7/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20201023163331-3e6fc7fc9c4c/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20201203190320-1bf35d6f28c2/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210122040257-d980be63207e/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
@@ -626,6 +631,7 @@ golang.org/x/net v0.0.0-20200520182314-0ba52f642ac2/go.mod h1:qpuaurCH72eLCgpAm/
 golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
+golang.org/x/net v0.0.0-20200904194848-62affa334b73/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20201010224723-4f7140c49acb/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201031054903-ff519b6c9102/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
@@ -833,7 +839,10 @@ golang.org/x/tools v0.0.0-20200618134242-20370b0cb4b2/go.mod h1:EkVYQZoAsY45+roY
 golang.org/x/tools v0.0.0-20200729194436-6467de6f59a7/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200804011535-6c149bb5ef0d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200825202427-b303f430e36d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
+golang.org/x/tools v0.0.0-20200828161849-5deb26317202/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200904185747-39188db58858/go.mod h1:Cj7w3i3Rnn0Xh82ur9kSqwfTHTeVxaDqrfMjpcNT6bE=
+golang.org/x/tools v0.0.0-20200915173823-2db8f0ff891c/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
+golang.org/x/tools v0.0.0-20200918232735-d647fc253266/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
 golang.org/x/tools v0.0.0-20201110124207-079ba7bd75cd/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20201201161351-ac6f37ff4c2a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20201208233053-a543418bbed2/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
@@ -869,6 +878,8 @@ google.golang.org/api v0.24.0/go.mod h1:lIXQywCXRcnZPGlsd8NbLnOjtAoL6em04bJ9+z0M
 google.golang.org/api v0.28.0/go.mod h1:lIXQywCXRcnZPGlsd8NbLnOjtAoL6em04bJ9+z0MncE=
 google.golang.org/api v0.29.0/go.mod h1:Lcubydp8VUV7KeIHD9z2Bys/sm/vGKnG1UHuDBSrHWM=
 google.golang.org/api v0.30.0/go.mod h1:QGmEvQ87FHZNiUVJkT14jQNYJ4ZJjdRF23ZXz5138Fc=
+google.golang.org/api v0.31.0/go.mod h1:CL+9IBCa2WWU6gRuBWaKqGWLFFwbEUXkfeMkHLQWYWo=
+google.golang.org/api v0.32.0/go.mod h1:/XrVsuzM0rZmrsbjJutiuftIzeuTQcEeaYcSk/mQ1dg=
 google.golang.org/api v0.35.0/go.mod h1:/XrVsuzM0rZmrsbjJutiuftIzeuTQcEeaYcSk/mQ1dg=
 google.golang.org/api v0.36.0/go.mod h1:+z5ficQTmoYpPn8LCUNVpK5I7hwkpjbcgqA7I34qYtE=
 google.golang.org/api v0.40.0/go.mod h1:fYKFpnQN0DsDSKRVRcQSDQNtqWPfM9i+zNPxepjRCQ8=
@@ -934,7 +945,10 @@ google.golang.org/genproto v0.0.0-20200618031413-b414f8b61790/go.mod h1:jDfRM7Fc
 google.golang.org/genproto v0.0.0-20200729003335-053ba62fc06f/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200804131852-c06518451d9c/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200825200019-8632dd797987/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
+google.golang.org/genproto v0.0.0-20200831141814-d751682dd103/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200904004341-0bd0a958aa1d/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
+google.golang.org/genproto v0.0.0-20200914193844-75d14daec038/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
+google.golang.org/genproto v0.0.0-20200921151605-7abf4a1a14d5/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20201109203340-2640f1f9cdfb/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20201201144952-b05cb90ed32e/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20201210142538-e3217bee35cc/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
@@ -1000,6 +1014,7 @@ google.golang.org/grpc v1.29.1/go.mod h1:itym6AZVZYACWQqET3MqgPpjcuV5QH3BxFS3Iji
 google.golang.org/grpc v1.30.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
 google.golang.org/grpc v1.31.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
 google.golang.org/grpc v1.31.1/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
+google.golang.org/grpc v1.32.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
 google.golang.org/grpc v1.33.1/go.mod h1:fr5YgcSWrqhRRxogOsw7RzIpsmvOZ6IcH4kBYTpR3n0=
 google.golang.org/grpc v1.33.2/go.mod h1:JMHMWHQWaTccqQQlmk3MJZS+GWXOdAesneDmEnv2fbc=
 google.golang.org/grpc v1.34.0/go.mod h1:WotjhfgOW/POjDeRt8vscBtXq+2VjORFy659qA51WJ8=


### PR DESCRIPTION
The previous implementation closed the file reader on each call to `Read` which made the operation very expensive, especially on large files when only reading 4k/call.

Instead of re-implementing a reader with support for `io.Seek`, this PR changes the implementation to use an existing reader for storage objects that supports `Seek`.

Comparing this change with a parquet file of 200LOC with 15 columns around 80M the previous implementation took ~6m30s and the current implementation takes ~18s.

In addition to that, this PR simplifies what we need to keep on the struct to be able to implement `Open` and `Create`.

This PR also does some hygiene to use more idiomatic Go:
* Don't use `self` or `this` for receiver name
* Use capital `ID` for identifiers
* Add compile time check that we implement `sources.ParquetFile`
* Rename `GcsFile` to `File` to make less stuttering (`gcs.File`)