### PR TITLE
Add a NewBufferFileFromBytesZeroAlloc factory function to create a Parquet buffer without additional memory allocation

### DIFF
--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -33,6 +33,11 @@ func NewBufferFileCapacity(cap int) *BufferFile {
 	return &BufferFile{buff: make([]byte, 0, cap)}
 }
 
+// ZeroCopyBufferFileFromBytes creates new in memory parquet buffer without memory allocation.
+func ZeroCopyBufferFileFromBytes(s []byte) *BufferFile {
+	return &BufferFile{buff: s}
+}
+
 func (bf BufferFile) Create(string) (source.ParquetFile, error) {
 	return NewBufferFile(), nil
 }

--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -33,8 +33,8 @@ func NewBufferFileCapacity(cap int) *BufferFile {
 	return &BufferFile{buff: make([]byte, 0, cap)}
 }
 
-// ZeroCopyBufferFileFromBytes creates new in memory parquet buffer without memory allocation.
-func ZeroCopyBufferFileFromBytes(s []byte) *BufferFile {
+// NewBufferFileFromBytesZeroAlloc creates new in memory parquet buffer without memory allocation.
+func NewBufferFileFromBytesZeroAlloc(s []byte) *BufferFile {
 	return &BufferFile{buff: s}
 }
 


### PR DESCRIPTION
Add a ZeroCopyBufferFileFromBytes factory function to create a Parquet buffer without additional memory allocation.